### PR TITLE
add MemberCenter, a part of CenterDetail Page and fixed footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,17 @@
-import AuthenticationPage from "./Pages/AuthenticationPage.tsx"
-import FrontPage from './Pages/FrontPage.tsx'
-import ShoppingCart from './Pages/ShoppingCartPage.tsx'
-import ShopPage from './Pages/ShopPage.tsx'
-import { Routes, Route } from 'react-router-dom'
+import AuthenticationPage from "./Pages/AuthenticationPage.tsx";
+import FrontPage from "./Pages/FrontPage.tsx";
+import ShoppingCart from "./Pages/ShoppingCartPage.tsx";
+import ShopPage from "./Pages/ShopPage.tsx";
+import { Routes, Route } from "react-router-dom";
 import ProductDetail from "./Pages/ProductDetail.tsx";
+import MemberCenter from "./Pages/MemberCenterPage.tsx";
+import CenterDetail from "./Pages/CenterDetailPage.tsx";
 
 function App() {
   return (
     <Routes>
       {/* Authentication route */}
-      <Route path='/members' Component={AuthenticationPage} />
+      <Route path="/auth" Component={AuthenticationPage} />
 
       {/* FrontPage route */}
       <Route path="/" Component={FrontPage} />
@@ -21,7 +23,13 @@ function App() {
       <Route path="/product" Component={ProductDetail} />
 
       {/* Shop route */}
-      <Route path='/shop' Component={ShopPage} />
+      <Route path="/shop" Component={ShopPage} />
+
+      {/* MemberCenter route*/}
+      <Route path="/member" Component={MemberCenter} />
+
+      {/* MemberCenterDetail route */}
+      <Route path="/member/detail" Component={CenterDetail} />
     </Routes>
   );
 }

--- a/src/Pages/AuthenticationPage.tsx
+++ b/src/Pages/AuthenticationPage.tsx
@@ -3,11 +3,11 @@ import Header from "../components/Header";
 import Footer from "../components/Footer";
 
 function AuthenticationPage() {
-  const [searchText, setSearchText] = useState(''); // 儲存搜尋文字
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [name, setName] = useState('');
-  const [activeTab, setActiveTab] = useState('sign-in');
+  const [searchText, setSearchText] = useState(""); // 儲存搜尋文字
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+  const [activeTab, setActiveTab] = useState("sign-in");
 
   // 當文字改變時更新 searchText
   const handleSearchChange = (text: string) => {
@@ -34,7 +34,7 @@ function AuthenticationPage() {
   };
 
   return (
-    <div className="flex flex-col item-center ">
+    <div className="flex flex-col item-center min-h-screen">
       <Header searchText={searchText} onSearchChange={handleSearchChange} />
       <div className="flex flex-col min-h-min my-10">
         {/* 中間內容區域 */}
@@ -149,4 +149,4 @@ function AuthenticationPage() {
   );
 }
 
-export default AuthenticationPage
+export default AuthenticationPage;

--- a/src/Pages/CenterDetailPage.tsx
+++ b/src/Pages/CenterDetailPage.tsx
@@ -15,7 +15,7 @@ interface InputFieldProps {
 }
 
 const Tabs: React.FC<TabProps> = ({ activeTab, onChange }) => {
-  const tabs = ["個人資料", "訂單狀態", "預填訂購資料"];
+  const tabs = ["個人資料", "訂單狀態", "預填訂購資料", "喜好項目"];
   return (
     <div className="flex justify-center space-x-8 text-gray-500 text-lg">
       {tabs.map((tab) => (

--- a/src/Pages/CenterDetailPage.tsx
+++ b/src/Pages/CenterDetailPage.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import { useLocation } from "react-router-dom";
+
+interface TabProps {
+  activeTab: string;
+  onChange: (tab: string) => void;
+}
+
+interface InputFieldProps {
+  label: string;
+  placeholder: string;
+  type?: string;
+}
+
+const Tabs: React.FC<TabProps> = ({ activeTab, onChange }) => {
+  const tabs = ["個人資料", "訂單狀態", "預填訂購資料"];
+  return (
+    <div className="flex justify-center space-x-8 text-gray-500 text-lg">
+      {tabs.map((tab) => (
+        <button
+          key={tab}
+          onClick={() => onChange(tab)}
+          className={`pb-2 ${
+            activeTab === tab
+              ? "text-purple-600 border-b-2 border-purple-600"
+              : "hover:text-purple-400"
+          }`}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+const InputField: React.FC<InputFieldProps> = ({
+  label,
+  placeholder,
+  type = "text",
+}) => {
+  return (
+    <div className="flex flex-col mb-4">
+      <label className="text-gray-700 mb-1">{label}</label>
+      <input
+        type={type}
+        placeholder={placeholder}
+        className="border border-gray-300 rounded-md p-2 focus:outline-none focus:border-purple-500"
+      />
+    </div>
+  );
+};
+
+const ProfileForm: React.FC = () => {
+  const imageSrc = "https://i.imgur.com/Xrebmu1.jpg";
+  return (
+    <div className="max-w-md mx-auto bg-purple-50 p-8 rounded-md ">
+      <div className="flex justify-center mb-6">
+        <img src={imageSrc} alt="Avatar" className="w-24 h-24 rounded-full" />
+      </div>
+      <InputField label="姓名" placeholder="姓名" />
+      <InputField label="信箱" placeholder="信箱" />
+      <div className="flex flex-col mb-4">
+        <label className="text-gray-700 mb-1">地址</label>
+        <select className="border border-gray-300 rounded-md p-2 mb-2">
+          <option>請選擇城市</option>
+        </select>
+        <select className="border border-gray-300 rounded-md p-2 mb-2">
+          <option>請選擇地區</option>
+        </select>
+        <input
+          type="text"
+          placeholder="請輸入街/弄/巷"
+          className="border border-gray-300 rounded-md p-2 focus:outline-none focus:border-purple-500"
+        />
+        <button className="w-full bg-purple-400 hover:bg-purple-500 text-white py-2 rounded-md mt-2">
+          修改
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const CenterDetail: React.FC = () => {
+  const path = useLocation();
+  const [activeTab, setActiveTab] = useState<string>(
+    path.state?.activeTab || "個人資料"
+  );
+  const [searchText, setSearchText] = useState("");
+  const handleSearchChange = (text: string) => {
+    setSearchText(text);
+  };
+
+  return (
+    <div className="flex flex-col items-center min-h-screen">
+      {/* 頁首 */}
+      <Header searchText={searchText} onSearchChange={handleSearchChange} />
+      <div className="bg-purple-50 flex flex-col items-center my-10 px-36">
+        <div className="w-full max-w-4xl mt-10">
+          <Tabs activeTab={activeTab} onChange={setActiveTab} />
+          {activeTab === "個人資料" && <ProfileForm />}
+        </div>
+      </div>
+      {/* 頁尾 */}
+      <Footer />
+    </div>
+  );
+};
+
+export default CenterDetail;

--- a/src/Pages/FrontPage.tsx
+++ b/src/Pages/FrontPage.tsx
@@ -46,7 +46,7 @@ const FrontPage = () => {
   }, []);
 
   return (
-    <div className="flex flex-col items-center ">
+    <div className="flex flex-col items-center min-h-screen">
       <Header searchText={searchText} onSearchChange={handleSearchChange} />
       {/* 上半部分：圖片背景，圖片可調整偏移量和縮放 */}
       <div

--- a/src/Pages/MemberCenterPage.tsx
+++ b/src/Pages/MemberCenterPage.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+
+interface ButtonProps {
+  text: string;
+  onClick?: () => void;
+  isPrimary?: boolean; // 用來區分主要button
+}
+
+const Button: React.FC<ButtonProps> = ({
+  text,
+  onClick,
+  isPrimary = false,
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full py-2 rounded-full text-lg font-semibold
+            ${
+              isPrimary
+                ? "bg-black text-white"
+                : "border-2 border-gray-300 text-gray-700"
+            }
+            hover:opacity-80 transition`}
+    >
+      {text}
+    </button>
+  );
+};
+
+const MemberCenter: React.FC = () => {
+  const [searchText, setSearchText] = useState("");
+  const navigate = useNavigate();
+
+  const handleSearchChange = (text: string) => {
+    setSearchText(text);
+  };
+
+  const handleLogout = () => {
+    console.log("登出");
+  };
+
+  const handleNavigate = (path: string, text: string) => {
+    navigate(path, { state: { activeTab: text } });
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      {/* 頁首 */}
+      <Header searchText={searchText} onSearchChange={handleSearchChange} />
+      {/* 內容 */}
+      <div className="w-full max-w-xs mx-auto mt-20 space-y-4">
+        <h1 className="text-3xl font-bold text-center">會員中心</h1>
+        <Button
+          text="個人資料"
+          onClick={() => handleNavigate("/member/detail", "個人資料")}
+        />
+        <Button
+          text="訂單狀態"
+          onClick={() => handleNavigate("/member/detail", "訂單狀態")}
+        />
+        <Button
+          text="預填訂購資料"
+          onClick={() => handleNavigate("/member/detail", "預填訂購資料")}
+        />
+        <Button
+          text="喜好項目"
+          onClick={() => handleNavigate("/member/detail", "喜好項目")}
+        />
+        <Button text="登出" isPrimary onClick={handleLogout} />
+      </div>
+      {/* 頁尾 */}
+      <Footer />
+    </div>
+  );
+};
+
+export default MemberCenter;

--- a/src/Pages/ProductDetail.tsx
+++ b/src/Pages/ProductDetail.tsx
@@ -13,7 +13,7 @@ const ProductDetail: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center min-h-screen">
       <Header searchText={searchText} onSearchChange={handleSearchChange} />
 
       <div className="flex flex-col lg:flex-row lg:items-start gap-8 p-8 w-full max-w-5xl ">

--- a/src/Pages/ShoppingCartPage.tsx
+++ b/src/Pages/ShoppingCartPage.tsx
@@ -70,7 +70,7 @@ const ShoppingCartPage = () => {
   }, [currentUserId]);
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center min-h-screen">
       <Header searchText={searchText} onSearchChange={handleSearchChange} />
 
       <div className="w-full max-w-4xl mt-8">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { AiOutlineClose } from 'react-icons/ai';
+import React from "react";
+import { AiOutlineClose } from "react-icons/ai";
 
 interface HeaderProps {
   searchText: string;
@@ -8,12 +8,14 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ searchText, onSearchChange }) => {
   const clearSearch = () => {
-    onSearchChange(''); // 清空搜尋文字
+    onSearchChange(""); // 清空搜尋文字
   };
 
   return (
     <header className="w-full flex items-center py-6 px-4 lg:px-10 bg-white relative shadow-lg hover:shadow-2xl transition-shadow duration-300 ease-in-out">
-      <a href="/" className="text-xl font-bold">🅱️</a>
+      <a href="/" className="text-xl font-bold">
+        🅱️
+      </a>
 
       {/* 搜尋框置中 */}
       <div className="absolute left-1/2 transform -translate-x-1/2 w-96 max-w-[40%] px-4 flex items-center">
@@ -35,13 +37,22 @@ const Header: React.FC<HeaderProps> = ({ searchText, onSearchChange }) => {
 
       {/* 右側功能按鈕 */}
       <div className="flex items-center space-x-2 lg:space-x-4 ml-auto">
-        <a href="/shop" className="px-3 py-1 lg:px-10 lg:py-1 border-2 border-gray-700 rounded-xl text-sm lg:text-base">
+        <a
+          href="/shop"
+          className="px-3 py-1 lg:px-10 lg:py-1 border-2 border-gray-700 rounded-xl text-sm lg:text-base"
+        >
           Shop
         </a>
-        <a href="/members" className="px-3 py-1 lg:px-10 lg:py-1 border-3 border-gray-700 rounded-xl text-sm lg:text-base">
+        <a
+          href="/auth"
+          className="px-3 py-1 lg:px-10 lg:py-1 border-3 border-gray-700 rounded-xl text-sm lg:text-base"
+        >
           Members
         </a>
-        <a href="/cart" className="px-3 py-1 lg:px-10 lg:py-1 border-2 border-gray-700 rounded-xl text-sm lg:text-base">
+        <a
+          href="/cart"
+          className="px-3 py-1 lg:px-10 lg:py-1 border-2 border-gray-700 rounded-xl text-sm lg:text-base"
+        >
           Cart
         </a>
       </div>


### PR DESCRIPTION
## Add MemberCenter, Partial CenterDetail Page and fixed footer
### MemberCenter 會員中心
- 目前已將"個人資料"、"訂單狀態"、"預填訂購資料"按下後，會跳轉到相對應的Detail Page
- "喜好項目" 按下後，尚未能轉到該頁面，待頁面完成後，會補上

### CenterDetail Page 會員詳細內容
- 目前已將大致上畫面建好，剩下 "訂單狀態"、"預填訂購資料"的內容未完成
- "個人資料"資料填寫，placeholder應該要顯示已有資料，按下修改後會call API 進行修改，待後端完成後，將功能補齊

### Fixed the footer problem 
- problem: Footer在不同裝置(解析度)上不會在頁面的最下方
- solution: 將每個頁面最外層的`<div>`加上`min-h-screen`，有改善，目前尚未出現其他問題

> 向世人道歉，我有用Prettier，所以Save file的時候，會導致格式化方式不同，我很抱歉....